### PR TITLE
docs(api): Update outdated links and information

### DIFF
--- a/api/creating-an-api.md
+++ b/api/creating-an-api.md
@@ -6,26 +6,26 @@ To create an API that's part of the TELUS Digital API platform, there are a numb
 
 ## What
 
-* APIs should be created using the [API starter kit](https://github.com/telusdigital/api-starter-kit)
+* APIs should be created using the [API starter kit](https://github.com/telus/api-starter-kit)
 * If your API requires the use of SDF, it must be deployed to the `o-api-platform` project in OpenShift. To get it deployed there, follow instructions using the [shippy-cli](https://github.com/telus/shippy-cli). Otherwise, the API may be hosted in a different OpenShift project.
 APIs that need to call services behind SDF or other digital APIs needs to be behind [Auth Proxy](authorization-proxy.md). To use Auth Proxy you'll need to:
   * Configure your API as a [new target](https://github.com/telus/authorization-proxy/tree/master/src/config/application-wide) in all required environments.
   * If your API is outside the `o-api-platform`, use the openshift URL of your service as the target.
-  * If your API requires to be authenticated, you must add your API name to the default.js file under the proper domain (Telus, koodo, etc) [here](https://github.com/telusdigital/authorization-proxy/blob/master/src/config/request-context)
+  * If your API requires to be authenticated, you must add your API name to the default.js file under the proper domain (Telus, koodo, etc) [here](https://github.com/telus/authorization-proxy/blob/master/src/config/request-context)
 * Ensure that you have updated documentation in your API's GitHub repository under /swagger.
 You will need to link your documentation from the [main hub](https://github.com/telus/api-platform-docs/tree/master/src/config) under the appropriate environment.
 
 ## How
 
 There are a number of TELUS libraries that make building digital APIs easier:
-* [node-utility-middlewares](https://github.com/telusdigital/node-utility-middlewares)
-* [express-error-handlers](https://github.com/telusdigital/express-error-handlers)
-* [api-platform-utils](https://github.com/telusdigital/api-platform-utils)
-* [api-platform-middleware](https://github.com/telusdigital/api-platform-middleware)
+* [node-utility-middlewares](https://github.com/telus/node-utility-middlewares)
+* [express-error-handlers](https://github.com/telus/express-error-handlers)
+* [api-platform-utils](https://github.com/telus/api-platform-utils)
+* [api-platform-middleware](https://github.com/telus/api-platform-middleware)
 
 
 ## References
 
 - [Authorization Proxy](authorization-proxy.md)
 - [API Platform Swagger](https://www.telus.com/api-platform/home/)
-- [API Starter Kit](https://github.com/telusdigital/api-starter-kit)
+- [API Starter Kit](https://github.com/telus/api-starter-kit)

--- a/api/creating-an-api.md
+++ b/api/creating-an-api.md
@@ -6,12 +6,14 @@ To create an API that's part of the TELUS Digital API platform, there are a numb
 
 ## What
 
-* APIs should start from the [API starter kit](https://github.com/telusdigital/api-starter-kit)
-* APIs should be deployed to the `api-platform` project in OpenShift. If you need access, follow the steps described [here](https://github.com/telusdigital/openshift-cluster-provisioning/).
-APIs that need to call services behind SDF or other digital APIs should be behind [Auth Proxy](authorization-proxy.md). To use Auth Proxy you'll need to:
-  * Configure your API as a [new target](https://github.com/telusdigital/authorization-proxy/blob/master/src/config/api-targets/production.js)
-  * Make sure the Oauth scope required by the service you want to call has been added to the [configuration](https://github.com/telusdigital/authorization-proxy/blob/master/src/config/sdf-env/prod.js)
-* Update the [Platform API docs](https://github.com/telusdigital/api-platform-docs) to include the [Swagger](https://swagger.io/) documentation for your service
+* APIs should be created using the [API starter kit](https://github.com/telusdigital/api-starter-kit)
+* If your API requires the use of SDF, it must be deployed to the `o-api-platform` project in OpenShift. To get it deployed there, follow instructions using the [shippy-cli](https://github.com/telus/shippy-cli). Otherwise, the API may be hosted in a different OpenShift project.
+APIs that need to call services behind SDF or other digital APIs needs to be behind [Auth Proxy](authorization-proxy.md). To use Auth Proxy you'll need to:
+  * Configure your API as a [new target](https://github.com/telus/authorization-proxy/tree/master/src/config/application-wide) in all required environments.
+  * If your API is outside the `o-api-platform`, use the openshift URL of your service as the target.
+  * If your API requires to be authenticated, you must add your API name to the default.js file under the proper domain (Telus, koodo, etc) [here](https://github.com/telusdigital/authorization-proxy/blob/master/src/config/request-context)
+* Ensure that you have updated documentation in your API's GitHub repository under /swagger.
+You will need to link your documentation from the [main hub](https://github.com/telus/api-platform-docs/tree/master/src/config) under the appropriate environment.
 
 ## How
 


### PR DESCRIPTION
## Overview

The documentation for creating a new API under auth-proxy is outdated with broken links and sparse information. This is an update to fix that.

### Features

- update how to add API to the o-api-platform openshift project.
- update a conditional whether you need to add OAuth scopes or not
- update where you need to write documentation for your API

---

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [ ] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
