### PR TITLE
docs: fix typo in API performance standards

### DIFF
--- a/performance/api-performance-standards.md
+++ b/performance/api-performance-standards.md
@@ -21,7 +21,7 @@ The majority of our applications call **a minimum of 2 APIs** for the initial pa
 ![TTFB](ttfb_api_performance.jpg "Logo Title Text 1")
 
 
-Considering the time also required by our own application logic, routing, database queries, etc., in order to remain under 600 ms for TTFB, **our APIs to should have an <u>average total response time of under 200ms</u> for a <u>throughput of up to 2500 rpm</u><sup>5</sup> (requests per minute)**.
+Considering the time also required by our own application logic, routing, database queries, etc., in order to remain under 600 ms for TTFB, **our APIs should have an <u>average total response time of under 200ms</u> for a <u>throughput of up to 2500 rpm</u><sup>5</sup> (requests per minute)**.
 
 ## How
 


### PR DESCRIPTION
### Fixes

- adjust grammar in API performance standards doc

---

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
