### PR TITLE
fix(docs): correctly link to document template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,5 +26,5 @@ Your rationale.
 - [ ] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
 - [ ] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format
 
-[template]: ../.template.md
+[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
 [karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html


### PR DESCRIPTION
## Overview

Fixes issue #130

### Fixes

- link to documentation template in PR body template

---

#### Meta

- [ ] provide a descriptive topic
- [ ] provide an overview of contribution
- [ ] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [ ] documentation format follows [this template][template]
- [ ] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [ ] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [ ] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
