### PR TITLE
feat(auto-assign): use pro-bot auto assign feature to automate assigning reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,10 @@
+addReviewers: true
+
+addAssignees: true
+
+reviewers: 
+  - ruxandrafed
+  - kspaans
+  - ahmadnassri
+
+numberOfReviewers: 2


### PR DESCRIPTION
automating is always better, especially for small things like assignee on pull requests

### Features

- use Pro Bot to automate assignees

---

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html