### PR TITLE
doc(secrets): add HowTo: create and consume secrets in json format

### DIFF
--- a/delivery/secrets.md
+++ b/delivery/secrets.md
@@ -32,6 +32,87 @@ Secrets can be nested in a tree, and users/groups can be given access to specifi
 
 Rather than provisioning the secrets from HashiCorp Vault into Kubernetes, and exposing them to the app, the app can instead get a Vault access token and query it directly for secrets. We have not tested this capability yet, but it's where we'd like to go `:)`.
 
+### HowTo: create and consume secrets in json format
+
+#### Create secret into Vault via Shippy
+
+```bash
+shippy project my-project
+```
+```bash
+shippy create secret my-secrets
+```
+or if already created:
+```bash
+shippy edit secret my-secrets
+```
+With
+* Key: field value (e.g. `billing`)
+* Value: json content, e.g.:
+```json
+module.exports = {
+    defaultCustomer: {
+      username: 'blablabla@telusinternal.com',
+      password: 'bliblibli',
+      encryptedBAN: 'TchoukTchouk',
+      BAN: '12345678',
+      BanType: 'Mobility'
+    },
+    ownerBillingSummary: {
+      username: 'blublublu@telusinternal.com',
+      password: 'blobloblo',
+      encryptedBAN: 'TchickTchick',
+      BAN: '87654321',
+      BanType: 'Mobility',
+      accountOwner: 'BILLING SUMMARY OWNER (account owner)',
+      billFormat: 'Paper bill enabled',
+      billingAddressValue: '300 CONSILIUM PLACE, TORONTO ON, M1H3J3'
+    }
+  }
+```
+
+#### Update the Openshift installation file to get the secrets added to the project
+```
+mkdir fixtures \
+  && shippy get secret my-secrets --my-project --field=billing > fixtures/billing.js \
+  && shippy get secret my-secrets --my-project --field=login > fixtures/login.js \
+  && oc create secret generic customer-secret --from-file=fixtures --dry-run -o yaml | oc apply -f -
+rm -rf fixtures
+```
+
+#### Update the Openshift script file to get the secrets mounted in the container
+```bash
+        "volumeMounts":[{
+          "name": "customers-volume",
+          "readOnly": true,
+          "mountPath": "/app/fixtures/customers"
+        }]
+      }],
+      "volumes":[{
+        "name":"customers-volume",
+        "secret":{
+            "secretName":"customer-secret"
+        }
+      }]
+```
+or the Openshift template:
+```
+              volumeMounts:
+                - name: customers-volume
+                  mountPath: /app/fixtures/customers
+                  readOnly: true
+          volumes:
+            - name: customers-volume
+              secret:
+                secretName: customer-secret
+```
+
+#### Update the [init.sh](init.sh) file that will pull the secrets and generate a json file locally
+```bash
+mkdir -p e2e/fixtures/customers
+shippy get secret my-secrets --my-project --field=billing > e2e/fixtures/customers/billing.js
+```
+
 ## Who
 
 @delivery

--- a/delivery/secrets.md
+++ b/delivery/secrets.md
@@ -47,8 +47,8 @@ or if already created:
 shippy edit secret my-secrets
 ```
 With
-* Key: field value (e.g. `billing`)
-* Value: json content, e.g.:
+- Key: field value (e.g. `billing`)
+- Value: json content, e.g.:
 ```json
 module.exports = {
     defaultCustomer: {
@@ -71,8 +71,10 @@ module.exports = {
   }
 ```
 
-#### Update the Openshift installation file to get the secrets added to the project
-```
+#### Update the Openshift installation file
+Purpose is to get the secrets added to the project
+
+```bash
 mkdir fixtures \
   && shippy get secret my-secrets --my-project --field=billing > fixtures/billing.js \
   && shippy get secret my-secrets --my-project --field=login > fixtures/login.js \
@@ -80,8 +82,10 @@ mkdir fixtures \
 rm -rf fixtures
 ```
 
-#### Update the Openshift script file to get the secrets mounted in the container
-```bash
+#### Update the Openshift script file
+Purpose is to get the secrets mounted in the container
+
+```json
         "volumeMounts":[{
           "name": "customers-volume",
           "readOnly": true,
@@ -96,7 +100,7 @@ rm -rf fixtures
       }]
 ```
 or the Openshift template:
-```
+```yml
               volumeMounts:
                 - name: customers-volume
                   mountPath: /app/fixtures/customers
@@ -107,7 +111,9 @@ or the Openshift template:
                 secretName: customer-secret
 ```
 
-#### Update the [init.sh](init.sh) file that will pull the secrets and generate a json file locally
+#### Update the [init.sh](init.sh) file 
+Purpose is to pull the secrets and generate a json file locally
+
 ```bash
 mkdir -p e2e/fixtures/customers
 shippy get secret my-secrets --my-project --field=billing > e2e/fixtures/customers/billing.js


### PR DESCRIPTION
## Overview

> HowTo is giving tips for how to create secrets in a json file with Shippy and how to consume them with Openshift and Locally

[Technology Forum][technology-forum] where this issue was discussed: telus/technology-forum/issues/174

### Details

> - add steps to create and consume secrets with Openshift and Locally

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [ ] provided a descriptive topic and overview of contribution
- [ ] documentation format follows the [topic template][template]
- [ ] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [ ] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [ ] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [ ] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-forks]: https://help.github.com/articles/syncing-a-fork/
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
