### PR TITLE
doc(databases): add note re database access

### DIFF
--- a/development/databases.md
+++ b/development/databases.md
@@ -23,6 +23,7 @@ To gain access to Amazon IAM, you can submit a pull request to the Data VPC IAM 
 
 - Any databases storing personal information must go through a security review
 - Avoid "database integration" by ensuring that you aren't sharing one database between multiple apps. Instead, front it with a shared microservice that provides a contract for communicating with the database.
+- To access your database, run a container in OpenShift containing the CLI interface for the database you have provisioned, e.g. run a container containing `psql` to access your [PostgreSQL](https://www.postgresql.org) instance.
 - TODO... more!
 
 ## Who


### PR DESCRIPTION
## Overview

There's no guidance as to the preferred route for accessing a database instance once provisioned. Add one.

### Details

- adds a simple suggestion as to the preferred means of accessing a database hosted on AWS

#### Meta

- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials