### PR TITLE
chore: testing probot centralized config

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,3 +1,5 @@
+_extends: github-settings
+
 repository:
   name: reference-architecture
   description: TELUS Reference Architecture Documentation
@@ -5,13 +7,6 @@ repository:
   homepage: https://telus.com/digital
   private: false
   has_issues: false
-  has_wiki: false
-  has_downloads: false
-  has_projects: false
-  default_branch: master
-  allow_squash_merge: true
-  allow_merge_commit: false
-  allow_rebase_merge: true
 
 labels:
   - name: security
@@ -26,7 +21,7 @@ labels:
     description: New feature or request
     color: 5EBEFF
 
-  - name: optimizaiton
+  - name: optimization
     description: Performance or Code Optimization
     color: 5EBEFF
 
@@ -58,22 +53,10 @@ branches:
   - name: master
     protection:
       required_pull_request_reviews:
-        # disable until this issue is closed: https://github.com/probot/settings/issues/87
-        # required_approving_review_count: 1
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
         dismissal_restrictions:
-          users: []
           teams:
             - architecture-support
 
-      required_status_checks:
-        strict: true
-        contexts: []
-
-      enforce_admins: true
-
       restrictions:
-        users: []
         teams:
           - architecture-support


### PR DESCRIPTION
## Overview

This repository uses [Probot settings](https://probot.github.io/apps/settings/). 
We recently discovered there is a way to centralize default settings for our Github repos, and then extend them in each project, with the ability to override and/or configure additional settings. 

I created a dedicated repo to host the centralized config [here](https://github.com/telus/github-settings) and, with this PR, I want to test if extending the settings works as expected.

### Details

- Updated `.github/settings.yml` and removed anything that already exists in the default config.
- Settings that have to be overridden have been repeated, e.g. restrictions for who can push to `master`, etc.

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-forks]: https://help.github.com/articles/syncing-a-fork/
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
