### PR TITLE
docs(security): update testing/security docs with npm audit

### DIFF
--- a/testing/nonfunctional/security.md
+++ b/testing/nonfunctional/security.md
@@ -10,30 +10,17 @@ Build continuous security into our delivery pipeline, so that we monitor our app
 
 ## How
 
-## When
+### NPM Audit
 
-## Standards
+Our [starter kits](../development/starter-kits.md) ship out of the box with security audits, done using [npm audit](https://docs.npmjs.com/cli/audit). Running `npm audit` assesses package dependencies for security vulnerabilities and allows us to find and fix known vulnerabilities in dependencies that could cause data loss, service outages, unauthorized access to sensitive information, or other issues. 
 
-Security team to instill and maintain
-
-### Node Security Platform
-
-Our [starter kits](../development/starter-kits.md) ship out of the box with [nsp](https://nodesecurity.io/) to scan the `package.json` for any known vulnerabilities. Our pipeline will fail if any are found.
-
-### TwistLock
-
-TODO
-
-### Clair
-
-TODO
+Failing the audit will cause the pipeline to fail, so you should address the issues before pushing any code. To automatically install any compatible (not semver-major) updates to vulnerable dependencies, run `npm audit fix`. For more information, please refer to the NPM documentation.
 
 ## Who
 
-@delivery @security @dev
+@everyone
 
 ## References
 
-- [Node security platform](https://nodesecurity.io/)
-- [Twistlock](https://www.twistlock.com)
-- [Clair](https://coreos.com/clair/docs/latest/)
+- [NPM - `npm audit` docs](https://docs.npmjs.com/cli/audit)
+- [NPM - About security audits](https://docs.npmjs.com/getting-started/running-a-security-audit)


### PR DESCRIPTION
## Overview

Replacing docs on `nsp` with `npm audit`.
Tech forum issue: https://github.com/telus/technology-forum/issues/191

### Details

- Replace `nsp` with `npm audit`
- Remove TODO and empty sections (Twistlock, Clair references) - @tavogel, do we use those or want to use them?
- To do: we should probably add a reference to Contrast (separate page) here. See https://github.com/telus/reference-architecture/pull/137.

---

#### Meta

> Please read and confirm each of the following:

- [x] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-forks]: https://help.github.com/articles/syncing-a-fork/
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
