### PR TITLE
docs(testing): fix typos in accessibility document

### DIFF
--- a/testing/nonfunctional/accessibility.md
+++ b/testing/nonfunctional/accessibility.md
@@ -20,9 +20,9 @@ We also use text-to-speech engines (screen readers) like [NVDA](https://www.nvac
 
 ## When
 
-Writing analytics tests: Upon story completion, make sure to include the assertion
+Accessibility tests are written near the end of a story. While writing your story, be sure to include an assertion that validates your accessibility criteria.
 
-Running analytics tests: As part of the delivery pipeline
+The delivery pipeline automatically runs accessibility tests and will notify you of any failures.
 
 ## Who
 


### PR DESCRIPTION
Change usages of 'analytics' to 'accessibility'

## Overview

- This updates some words in the accessibility test document. Some usages of `analytics` may be incorrect.
- Add clarity to the `when` section

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [ ] provided a descriptive topic and overview of contribution
- [ ] documentation format follows the [topic template][template]
- [ ] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [ ] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [ ] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [ ] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-forks]: https://help.github.com/articles/syncing-a-fork/
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
