### PR TITLE
Update github org name & npm org scope

### DIFF
--- a/api/authorization-proxy.md
+++ b/api/authorization-proxy.md
@@ -22,4 +22,4 @@ The Authorization Proxy handles:
 
 ## How
 
-The Authorization Proxy [README](https://github.com/telusdigital/authorization-proxy)
+The Authorization Proxy [README](https://github.com/telus/authorization-proxy)

--- a/api/schema-validation.md
+++ b/api/schema-validation.md
@@ -42,9 +42,9 @@ When consuming an API, response data should be validated whether or not validati
 When handling a schema validation error, if the API is unable to finish processing the client's request, then the API should respond with the HTTP status code `503 Service Unavailable` to indicate that a downstream dependency failed.
 
 Example:
-- [Ajv validation logic](https://github.com/telusdigital/api-platform-utils/blob/master/src/validate-body/index.js)
+- [Ajv validation logic](https://github.com/telus/api-platform-utils/blob/master/src/validate-body/index.js)
 in `api-platform-utils`
-- [Schema](https://github.com/telusdigital/api-platform-order/blob/master/src/domain/order-automation/quote/quoteResponseSchema.js) for BTO Order Management Service GET quote response in api-platform-order
+- [Schema](https://github.com/telus/api-platform-order/blob/master/src/domain/order-automation/quote/quoteResponseSchema.js) for BTO Order Management Service GET quote response in api-platform-order
 
 ## References
 

--- a/delivery/inbound-proxies.md
+++ b/delivery/inbound-proxies.md
@@ -21,12 +21,12 @@ We present www.telus.com and a few subdomains used to route to application envir
 
 To have traffic from `http://www.wctest.telus.com/en/bc/foo/bar` proxied to your application, you need to:
 
-1. Fork [inbound.telus-gateway-staging-config](https://github.com/telusdigital/inbound.telus-gateway-staging-config)
+1. Fork [inbound.telus-gateway-staging-config](https://github.com/telus/inbound.telus-gateway-staging-config)
 2. Create nginx rule(s) that matches the traffic you're wanting to serve, and proxies them to where your application is hosted
-3. Create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telusdigital/inbound.telus-gateway-staging-config#writing-tests)
-4. Run the tests locally ([README](https://github.com/telusdigital/inbound.telus-gateway-staging-config/blob/master/README.md#set-up-everything-and-run-the-tests))
+3. Create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telus/inbound.telus-gateway-staging-config#writing-tests)
+4. Run the tests locally ([README](https://github.com/telus/inbound.telus-gateway-staging-config/blob/master/README.md#set-up-everything-and-run-the-tests))
 5. Commit your changes to a branch that contains the Jira Issue Stub, ie BMK-560
-6. Submit a [pull request](https://github.com/telusdigital/inbound.telus-gateway-staging-config). If your request needs merging at a specific time, please note that in your pull request.
+6. Submit a [pull request](https://github.com/telus/inbound.telus-gateway-staging-config). If your request needs merging at a specific time, please note that in your pull request.
 7. Your pull request will notify the delivery team in #g-delivery. If you didn't write any tests, your pull request won't get merged.
 8. Once the pull request is merged, the changes will be deployed automatically.
 
@@ -34,12 +34,12 @@ To have traffic from `http://www.wctest.telus.com/en/bc/foo/bar` proxied to your
 
 To have traffic from `http://www.telus.com/en/bc/foo/bar` proxied to your application, you need to:
 
-1. Fork [inbound.telus-gateway-production-config](https://github.com/telusdigital/inbound.telus-gateway-production-config)
+1. Fork [inbound.telus-gateway-production-config](https://github.com/telus/inbound.telus-gateway-production-config)
 2. Create nginx rule(s) that matches the traffic you're wanting to serve, and proxies them to where your application is hosted
-3. Create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telusdigital/inbound.telus-gateway-production-config#writing-tests)
-4. Run the tests locally ([README](https://github.com/telusdigital/inbound.telus-gateway-production-config/blob/master/README.md#set-up-everything-and-run-the-tests))
+3. Create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telus/inbound.telus-gateway-production-config#writing-tests)
+4. Run the tests locally ([README](https://github.com/telus/inbound.telus-gateway-production-config/blob/master/README.md#set-up-everything-and-run-the-tests))
 5. Commit your changes to a branch that contains the Jira Issue Stub, ie BMK-560
-6. Submit a [pull request](https://github.com/telusdigital/inbound.telus-gateway-production-config). If your request needs merging at a specific time, please note that in your pull request.
+6. Submit a [pull request](https://github.com/telus/inbound.telus-gateway-production-config). If your request needs merging at a specific time, please note that in your pull request.
 7. Your pull request will notify the delivery team in #g-delivery. If you didn't write any tests, your pull request won't get merged.
 8. Once the pull request is merged, the changes will be deployed automatically.
 
@@ -49,5 +49,5 @@ To have traffic from `http://www.telus.com/en/bc/foo/bar` proxied to your applic
 
 ## References
 
-- [Preproduction](https://github.com/telusdigital/inbound.telus-gateway-staging-config)
-- [Production](https://github.com/telusdigital/inbound.telus-gateway-production-config)
+- [Preproduction](https://github.com/telus/inbound.telus-gateway-staging-config)
+- [Production](https://github.com/telus/inbound.telus-gateway-production-config)

--- a/delivery/jenkins.md
+++ b/delivery/jenkins.md
@@ -14,7 +14,7 @@ OpenShift also alleviates the traditional achilles heel of Jenkins: being a hype
 
 ### Jenkins starter kit
 
-Currently we are using an OpenShift dedicated cluster. Sadly, this means we cannot update the default Jenkins Docker image, to include plugins like the Slack notifier. As such, we have extended the OpenShift image with our own, in a separate git repository. To kick off any reference architecture project, you'll need to install the [Jenkins Starter Kit](https://github.com/telusdigital/openshift-jenkins-starter-kit) to your project.
+Currently we are using an OpenShift dedicated cluster. Sadly, this means we cannot update the default Jenkins Docker image, to include plugins like the Slack notifier. As such, we have extended the OpenShift image with our own, in a separate git repository. To kick off any reference architecture project, you'll need to install the [Jenkins Starter Kit](https://github.com/telus/openshift-jenkins-starter-kit) to your project.
 
 ### Jenkinsfile
 

--- a/delivery/openshift.md
+++ b/delivery/openshift.md
@@ -44,7 +44,7 @@ Each outcome team also gets an `o-outcome-team` namespace. Only users who are ad
 
 ### OpenShift Cluster Provisioning
 
-Our [OpenShift Cluster Provisioning](https://github.com/telusdigital/openshift-cluster-provisioning) scripts set up the baseline of our OpenShift clusters. All projects and user access roles are defined here. You'll have to submit a pull request to this git repository, if you want to set up a user, squad or project.
+Our [OpenShift Cluster Provisioning](https://github.com/telus/openshift-cluster-provisioning) scripts set up the baseline of our OpenShift clusters. All projects and user access roles are defined here. You'll have to submit a pull request to this git repository, if you want to set up a user, squad or project.
 
 ### Configurations
 

--- a/delivery/shippy.md
+++ b/delivery/shippy.md
@@ -8,7 +8,7 @@ We want a common tool to access our delivery infrastructure and development envi
 
 The indefatigable TELUS digital delivery platform assistant.
 
-- Clone and deploy [reference architecture](https://github.com/telusdigital/reference-architecture) starter kits
+- Clone and deploy [reference architecture](https://github.com/telus/reference-architecture) starter kits
 - Onboard users into OpenShift & HashiCorp Vault
 - Create squads & assign tech leads & members
 - Create projects & assign them to squads
@@ -60,5 +60,5 @@ Shippy core values:
 
 ## References
 
-- [shippy-cli](https://github.com/telusdigital/shippy-cli)
-- [@telusdigital/shippy-cli](https://www.npmjs.com/package/@telusdigital/shippy-cli)
+- [shippy-cli](https://github.com/telus/shippy-cli)
+- [@telus/shippy-cli](https://www.npmjs.com/package/@telus/shippy-cli)

--- a/development/caching.md
+++ b/development/caching.md
@@ -67,12 +67,12 @@ To gain access to Amazon IAM, you can submit a pull request to the Data VPC IAM 
 ### Resources
 
 - [Elasticache Docs](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/WhatIs.html)
-- [Terraform Elasticache Module](https://github.com/telusdigital/terraform-aws_elasticache_cluster)
+- [Terraform Elasticache Module](https://github.com/telus/terraform-aws_elasticache_cluster)
 - [Data VPC MAIN][terraform-openshift-datavpc-main]
 - [Data VPC SANDBOX][terraform-openshift-datavpc-sandbox]
 - [Data VPC IAM][terraform-openshift-datavpc-iam]
 
 [cache-control-spec]: http://httpwg.org/specs/rfc7234.html#header.cache-control
-[terraform-openshift-datavpc-main]: https://github.com/telusdigital/terraform-openshift-datavpc-main
-[terraform-openshift-datavpc-sandbox]: https://github.com/telusdigital/terraform-openshift-datavpc-sandbox
-[terraform-openshift-datavpc-iam]: https://github.com/telusdigital/terraform-openshift-datavpc-iam
+[terraform-openshift-datavpc-main]: https://github.com/telus/terraform-openshift-datavpc-main
+[terraform-openshift-datavpc-sandbox]: https://github.com/telus/terraform-openshift-datavpc-sandbox
+[terraform-openshift-datavpc-iam]: https://github.com/telus/terraform-openshift-datavpc-iam

--- a/development/dependencies.md
+++ b/development/dependencies.md
@@ -17,7 +17,7 @@ The only setup necessary to get started with Renovate is to create a config file
 ```json
 {
   "extends": [
-    "@telusdigital"
+    "@telus"
   ]
 }
 ```

--- a/development/express.md
+++ b/development/express.md
@@ -30,10 +30,10 @@ We currently use Express v4.
 
 ### TELUS digital packages
 
-- [express-error-handlers](https://github.com/telusdigital/express-error-handlers)
-- [express-oauth2](https://github.com/telusdigital/express-oauth2) _(soon to be deprecated by Authorization Proxy)_
-- [express-locale](https://github.com/telusdigital/express-locale)
-- [node-utility-middlewares](https://github.com/telusdigital/node-utility-middlewares)
+- [express-error-handlers](https://github.com/telus/express-error-handlers)
+- [express-oauth2](https://github.com/telus/express-oauth2) _(soon to be deprecated by Authorization Proxy)_
+- [express-locale](https://github.com/telus/express-locale)
+- [node-utility-middlewares](https://github.com/telus/node-utility-middlewares)
 
 ## Who
 

--- a/development/git.md
+++ b/development/git.md
@@ -30,7 +30,7 @@ Team members utilising Git and contributing to project repositories can follow [
 - [Git][git]
 - [GitHub][github]
 
-[org]: https://github.com/orgs/telusdigital/people
+[org]: https://github.com/orgs/telus/people
 [contribution]: ../process/contribution-model.md
 [github-ssh]: https://help.github.com/articles/connecting-to-github-with-ssh/
 [github-gpg]: https://help.github.com/articles/signing-commits-using-gpg/

--- a/development/isomorphic.md
+++ b/development/isomorphic.md
@@ -16,7 +16,7 @@ Rather than sending a blank page with a JavaScript application, an isomorphic ap
 
 ## How
 
-The [TELUS Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit) is a boilerplate application, which is a [template](starter-kits.md) for building an Isomorphic/Universal React.js UI. It has a `client.js` and a `server.js`, which contain the relevant Isomorphic bootstrapping code. The rest of the code (the React components, the Redux state, etc.) is Universal and shared between server and client side.
+The [TELUS Isomorphic Starter Kit](https://github.com/telus/telus-isomorphic-starter-kit) is a boilerplate application, which is a [template](starter-kits.md) for building an Isomorphic/Universal React.js UI. It has a `client.js` and a `server.js`, which contain the relevant Isomorphic bootstrapping code. The rest of the code (the React components, the Redux state, etc.) is Universal and shared between server and client side.
 
 ## Who
 
@@ -26,4 +26,4 @@ Developers, developers, developers, developers.
 
 - [AirBnB Isomorphism](https://medium.com/airbnb-engineering/isomorphic-javascript-the-future-of-web-apps-10882b7a2ebc)
 - [Isomorphism vs Universal](https://medium.com/@ghengeveld/isomorphism-vs-universal-javascript-4b47fb481beb)
-- [Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit)
+- [Isomorphic Starter Kit](https://github.com/telus/telus-isomorphic-starter-kit)

--- a/development/libraries.md
+++ b/development/libraries.md
@@ -23,11 +23,11 @@ Any library should:
 - Be explicit about dependencies
 - Include documentation with example usage
 - Follow the versioning strategy defined [here](versioning.md)
-- Include [automated tests](https://github.com/telusdigital/reference-architecture/tree/master/testing)
-- Have clear [contribution guidelines](https://github.com/telusdigital/reference-architecture/blob/master/.github/CONTRIBUTING.md)
-- Use the [npm library starter Kit](https://github.com/telusdigital/npm-library-starter-kit) as a starting point.
+- Include [automated tests](https://github.com/telus/reference-architecture/tree/master/testing)
+- Have clear [contribution guidelines](https://github.com/telus/reference-architecture/blob/master/.github/CONTRIBUTING.md)
+- Use the [npm library starter Kit](https://github.com/telus/npm-library-starter-kit) as a starting point.
 
 ## References
 
 - [Versioning](versioning.md)
-- [npm library starter kit](https://github.com/telusdigital/npm-library-starter-kit)
+- [npm library starter kit](https://github.com/telus/npm-library-starter-kit)

--- a/development/libraries.md
+++ b/development/libraries.md
@@ -25,7 +25,7 @@ Any library should:
 - Follow the versioning strategy defined [here](versioning.md)
 - Include [automated tests](https://github.com/telus/reference-architecture/tree/master/testing)
 - Have clear [contribution guidelines](https://github.com/telus/reference-architecture/blob/master/.github/CONTRIBUTING.md)
-- Use the [npm library starter Kit](https://github.com/telus/npm-library-starter-kit) as a starting point.
+- Use the [npm library starter kit (@telus/create-library)](https://github.com/telus/create-library) as a starting point.
 
 ## References
 

--- a/development/npm.md
+++ b/development/npm.md
@@ -63,7 +63,7 @@ We currently have three shared accounts for specific purposes:
   - `npm version (major | minor | patch)`
   - `git push && git push --tags`
   - `npm publish`
-7. If your package needs to be private and internal to TELUS Digital, reach out to one of the [Architects](https://github.com/orgs/telus/teams/digital-architecture/members) for assistance in getting the package published in the `@telusdigital` organization and with read-only permissions assigned to the `telusdigital-dev` account token.
+7. If your package needs to be private and internal to TELUS Digital, reach out to one of the [Architects](https://github.com/orgs/telus/teams/digital-architecture/members) for assistance in getting the package published in the `@telus` organization and with read-only permissions assigned to the `telusdigital-dev` account token.
 
 ### Recommended file structure
 

--- a/development/react.md
+++ b/development/react.md
@@ -26,7 +26,7 @@ React code is used on the server and client, and can be used for mobile apps. (S
 
 The [TELUS Design System](http://tds.telus.com/) hosts and standardizes a library of React components. Where possible, the components in this library should be used rather than building new components. This ensures a consistent design language across all of our pages.
 
-The [TELUS Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit) is the standard starting point for building isomorphic Node.js and React applications. It contains boilerplate code developers can use with minimal change. The starter kit uses [webpack](webpack.md) and [babel](babel.md) to transpile React JSX and ES2015 code into browser-native ES5 code. Isomorphism is used to pre-render React components on a server before sending them to the browser. This reduces the amount of work on the browser by completing it on the server side. After the browser receives the rendered application, the browser is able to render more React components using AJAX requests to gather data.
+The [TELUS Isomorphic Starter Kit](https://github.com/telus/telus-isomorphic-starter-kit) is the standard starting point for building isomorphic Node.js and React applications. It contains boilerplate code developers can use with minimal change. The starter kit uses [webpack](webpack.md) and [babel](babel.md) to transpile React JSX and ES2015 code into browser-native ES5 code. Isomorphism is used to pre-render React components on a server before sending them to the browser. This reduces the amount of work on the browser by completing it on the server side. After the browser receives the rendered application, the browser is able to render more React components using AJAX requests to gather data.
 
 Generally speaking, business logic should not be in the React view layer. Business logic should be placed in the backend alongside all handling of downstream data sources. The backend should also expose data that matches the React component state.
 
@@ -38,7 +38,7 @@ Everyone!
 
 - [React.js](https://facebook.github.io/react/)
 - [React tutorials](https://egghead.io/technologies/react)
-- [TELUS Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit)
+- [TELUS Isomorphic Starter Kit](https://github.com/telus/telus-isomorphic-starter-kit)
 - [React Developer Tools](https://github.com/facebook/react-devtools)
 - [React Native](https://facebook.github.io/react-native/)
 - [ThoughtWorks Technology Radar](https://www.thoughtworks.com/radar/languages-and-frameworks/react-js)

--- a/development/redux.md
+++ b/development/redux.md
@@ -36,9 +36,9 @@ programming, and therefore highly unit testable.
 ## How
 
 Our
-[TELUS isomorphic starter kit](https://github.com/telusdigital/telus-isomorphic-starter-kit)
+[TELUS isomorphic starter kit](https://github.com/telus/telus-isomorphic-starter-kit)
 defines our standard UI application, with React and Redux at its heart. The
-[FAQ](https://github.com/telusdigital/telus-isomorphic-starter-kit/tree/master/ui#faq)
+[FAQ](https://github.com/telus/telus-isomorphic-starter-kit/tree/master/ui#faq)
 has a lot of information about how we use Redux.
 
 ### React Component

--- a/development/starter-kits.md
+++ b/development/starter-kits.md
@@ -24,9 +24,9 @@ They have been developed in a collaborative partnership with the following teams
 
 ### Ownership and updating
 
-No one team owns the starter kits. They are worked on collaboratively, with an open-source pull-request model. The standards are managed through the weekly [Architecture Forum](https://github.com/telusdigital/architecture-forum), on [#TechMondays](https://telusdigital.atlassian.net/wiki/display/techmondays/Schedule). If you are looking for a new feature to be added, you should join the forum and open an issue, although this is not required to submit a pull request.
+No one team owns the starter kits. They are worked on collaboratively, with an open-source pull-request model. The standards are managed through the weekly [Architecture Forum](https://github.com/telus/architecture-forum), on [#TechMondays](https://telusdigital.atlassian.net/wiki/display/techmondays/Schedule). If you are looking for a new feature to be added, you should join the forum and open an issue, although this is not required to submit a pull request.
 
-The starter kit projects are designed to be [named anything](https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/CLONING.md), and be [deployed to any OpenShift project](https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/openshift/README.md). We are working on [shippy](../delivery/shippy.md) to expedite the creation of projects in GitHub, using starter kit templates.
+The starter kit projects are designed to be [named anything](https://github.com/telus/telus-isomorphic-starter-kit/blob/master/CLONING.md), and be [deployed to any OpenShift project](https://github.com/telus/telus-isomorphic-starter-kit/blob/master/openshift/README.md). We are working on [shippy](../delivery/shippy.md) to expedite the creation of projects in GitHub, using starter kit templates.
 
 ### Make a change
 
@@ -48,6 +48,6 @@ Everyone!
 
 ## References
 
-- [Telus Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit)
-- [API Starter Kit](https://github.com/telusdigital/api-starter-kit)
-- [Starter Kit Starter Kit](https://github.com/telusdigital/starter-kit-starter-kit)
+- [Telus Isomorphic Starter Kit](https://github.com/telus/telus-isomorphic-starter-kit)
+- [API Starter Kit](https://github.com/telus/api-starter-kit)
+- [Starter Kit Starter Kit](https://github.com/telus/starter-kit-starter-kit)

--- a/development/uri-structure.md
+++ b/development/uri-structure.md
@@ -103,6 +103,6 @@ Any teams deploying to www.telus.com:
 
 [rfc-6570]: https://tools.ietf.org/html/rfc6570 "RFC 6570"
 
-[telus-gateway-staging-config]: https://github.com/telusdigital/inbound.telus-gateway-staging-config "inbound.telus-gateway-staging-config"
+[telus-gateway-staging-config]: https://github.com/telus/inbound.telus-gateway-staging-config "inbound.telus-gateway-staging-config"
 
-[telus-gateway-production-config]: https://github.com/telusdigital/inbound.telus-gateway-production-config "inbound.telus-gateway-production-config"
+[telus-gateway-production-config]: https://github.com/telus/inbound.telus-gateway-production-config "inbound.telus-gateway-production-config"

--- a/development/webpack.md
+++ b/development/webpack.md
@@ -10,7 +10,7 @@ Webpack builds an entire dependency graph for all of your file types, and lets y
 
 ## How
 
-We use Webpack 2.0 for any rich user interfaces, which need a lot of compilation, transpiling, etc. It is not commonly used for APIs. It is used in our [TELUS Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit/) to compile the React.js code into a rich [isomorphic](isomorphic.md) web application, that can be run in Node.js and in the browser, alike.
+We use Webpack 2.0 for any rich user interfaces, which need a lot of compilation, transpiling, etc. It is not commonly used for APIs. It is used in our [TELUS Isomorphic Starter Kit](https://github.com/telus/telus-isomorphic-starter-kit/) to compile the React.js code into a rich [isomorphic](isomorphic.md) web application, that can be run in Node.js and in the browser, alike.
 
 Webpack supports two modes of transpilation, based on the `NODE_ENV` environment variable.
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "@telusdigital"
+    "@telus"
   ]
 }

--- a/security/domain-management.md
+++ b/security/domain-management.md
@@ -8,7 +8,7 @@ In order to maintain customer trust and ensure a consistent experience when visi
 
 ### Digital Platform Applications
 
-TELUS digital properties that are on Digital Platform (RA) are to be routed through [inbound proxy](https://github.com/telusdigital/reference-architecture/blob/master/delivery/inbound-proxies.md) in order to be hosted as a context path under www.telus.com domain - example: www.telus.com/app
+TELUS digital properties that are on Digital Platform (RA) are to be routed through [inbound proxy](https://github.com/telus/reference-architecture/blob/master/delivery/inbound-proxies.md) in order to be hosted as a context path under www.telus.com domain - example: www.telus.com/app
 
 ### Whitelabel/Vendor hosted TELUS solutions
 
@@ -16,7 +16,7 @@ Whitelabel/Vendor hosted TELUS solutions (not on RA/Digital Platform) must follo
 
 ## How
 
-Digital Platform Applications must be configured to be routed through the [inbound proxy](https://github.com/telusdigital/reference-architecture/blob/master/delivery/inbound-proxies.md)<br>
+Digital Platform Applications must be configured to be routed through the [inbound proxy](https://github.com/telus/reference-architecture/blob/master/delivery/inbound-proxies.md)<br>
 
 All other applications, including Whitelabel/Vendor hosted TELUS solutions:
 

--- a/security/project-inception-and-security-process.md
+++ b/security/project-inception-and-security-process.md
@@ -15,8 +15,8 @@ A high-level overview of TELUS security process that a project team is required 
 The standard engagement of the TELUS security and privacy teams for a digital initiative is done through internal processes that must be coordinated by a TELUS prime. TELUS prime is typically a PO or tech lead who must also be a TELUS employee (not vendor), as he/she would require access to corporate network to access, submit and make changes to required online forms.
 
 - Environment security configuration:
-  - TELUS digital initiatives - staging and production environments must be configured to route through staging and production inbound proxy respectively as per [instructions](https://github.com/telusdigital/reference-architecture/blob/master/delivery/inbound-proxies.md).
-  - Vendor hosted/whitelabel TELUS solutions - Ensure that your development, staging or demo environments are not accessible over the internet. Staging environments must be ip-whitelisted to only a limited number of IP addresses that require access or secured with a server-level basic authentication. Production environment must follow [domain management](https://github.com/telusdigital/reference-architecture/blob/master/security/domain-management.md) process.
+  - TELUS digital initiatives - staging and production environments must be configured to route through staging and production inbound proxy respectively as per [instructions](https://github.com/telus/reference-architecture/blob/master/delivery/inbound-proxies.md).
+  - Vendor hosted/whitelabel TELUS solutions - Ensure that your development, staging or demo environments are not accessible over the internet. Staging environments must be ip-whitelisted to only a limited number of IP addresses that require access or secured with a server-level basic authentication. Production environment must follow [domain management](https://github.com/telus/reference-architecture/blob/master/security/domain-management.md) process.
 
 - Privacy Impact Assessment (PIA): Complete the form found at go/PIA. 
   - Allow 2 weeks to have a PIA prime assigned to work with you.

--- a/testing/functional/unit.md
+++ b/testing/functional/unit.md
@@ -61,4 +61,4 @@ ie: Given a `Card` that gets wrapped in an HoC, the directory structure should l
 
 [tdd]: https://en.wikipedia.org/wiki/Test-driven_development
 [sonarqube]: https://github.com/SonarSource/sonarqube
-[telus-sonarqube]: https://github.com/telusdigital/sonarqube
+[telus-sonarqube]: https://github.com/telus/sonarqube

--- a/testing/nonfunctional/analytics.md
+++ b/testing/nonfunctional/analytics.md
@@ -52,6 +52,6 @@ Analytics team to set
 
 [json-schema]: http://json-schema.org/
 
-[starter-kit]: https://github.com/telusdigital/telus-isomorphic-starter-kit
+[starter-kit]: https://github.com/telus/telus-isomorphic-starter-kit
 
 [nightwatch]: https://github.com/nightwatchjs/nightwatch

--- a/testing/nonfunctional/seo.md
+++ b/testing/nonfunctional/seo.md
@@ -154,15 +154,15 @@ For more information see [this documentation](https://support.google.com/webmast
 
 - `<meta property="og:title">`
 
-  - Should be identical to the page [Document Title](https://github.com/telusdigital/reference-architecture/blob/master/testing/nonfunctional/seo.md#document-title)
+  - Should be identical to the page [Document Title](https://github.com/telus/reference-architecture/blob/master/testing/nonfunctional/seo.md#document-title)
 
 - `<meta property="og:description">`
 
-  - Should be identical to the page [Meta Description](https://github.com/telusdigital/reference-architecture/blob/master/testing/nonfunctional/seo.md#meta-description)
+  - Should be identical to the page [Meta Description](https://github.com/telus/reference-architecture/blob/master/testing/nonfunctional/seo.md#meta-description)
 
 - `<meta property="og:url">`
 
-  - Should be identical to the page [ref=canonical](https://github.com/telusdigital/reference-architecture/blob/master/testing/nonfunctional/seo.md#canonical-url)
+  - Should be identical to the page [ref=canonical](https://github.com/telus/reference-architecture/blob/master/testing/nonfunctional/seo.md#canonical-url)
 
 - `<meta property="og:image">`
   - [ ] element should exist and be unique
@@ -312,7 +312,7 @@ For example, page 2 in a 10-page pagination sequence `https://www.telus.com/en/s
 
 ## How
 
-Incorporate [Telus-Lighthouse](https://github.com/telusdigital/telus-lighthouse) into your application and test regularly to ensure your pages comply with the SEO Standards above.
+Incorporate [Telus-Lighthouse](https://github.com/telus/telus-lighthouse) into your application and test regularly to ensure your pages comply with the SEO Standards above.
 
 ## Who
 

--- a/testing/tools_platforms/devicefarm-security.md
+++ b/testing/tools_platforms/devicefarm-security.md
@@ -41,7 +41,7 @@ Securing the devicefarm's physical resources, which includes:
 
 ## Who
 
-@telusdigital/digital-farmers @qa @peopleops
+@telus/digital-farmers @qa @peopleops
 
 ## References
 

--- a/testing/tools_platforms/devicefarm.md
+++ b/testing/tools_platforms/devicefarm.md
@@ -79,7 +79,7 @@ We have [farmville][farmville] which provides
 
 ## Who
 
-@telusdigital/digital-farmers @qa
+@telus/digital-farmers @qa
 
 ---
 
@@ -108,7 +108,7 @@ We have [farmville][farmville] which provides
 
 ### Tech
 
-- [Grid FW setup repo](https://github.com/telusdigital/farmville)
+- [Grid FW setup repo](https://github.com/telus/farmville)
 - [Machine setup](https://drive.google.com/open?id=1rkqCqPDlNR_aH4zrTGWEqb-jyF8jJ6-pI1EH13hl3rA)
 - [Framework requirements design](https://docs.google.com/presentation/d/1NlHf1CCi6PQ23HwIUYKgGEQcOrGelzJgb9ZKEwX21ZA)
 - [Grid setup](https://drive.google.com/open?id=1CNwNHZbw8i8rchWri6SmIffWFrocuJjTcgv0wNAo8RI)
@@ -140,7 +140,7 @@ We have [farmville][farmville] which provides
 
 [df media: nestcam]: devicefarm_media/nestcam.jpeg
 
-[farmville]: https://github.com/telusdigital/farmville
+[farmville]: https://github.com/telus/farmville
 
 [df media: webapp]: devicefarm_media/webapp.gif
 

--- a/testing/tools_platforms/devicefarmfaq.md
+++ b/testing/tools_platforms/devicefarmfaq.md
@@ -65,7 +65,7 @@ Long story short: Mac minis power devices as Appium nodes, connects to a Seleniu
 
 <details><summary>Q: How can I start using devicefarm for running my automated tests?</summary><p> 
 
-For web automation, if you are using Nightwatch.js, or you are still on the Ruby/Cucumber automation stack that we had previously implemented(yes it's still supported), then you are in luck! You can point to the Selenium server dedicated for devicefarm in your Selenium config. Where is this Selenium server you ask? Checkout our [starter-kit:e2e devicefarm config](https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/e2e/nightwatch.devicefarm.conf.js#L42)!
+For web automation, if you are using Nightwatch.js, or you are still on the Ruby/Cucumber automation stack that we had previously implemented(yes it's still supported), then you are in luck! You can point to the Selenium server dedicated for devicefarm in your Selenium config. Where is this Selenium server you ask? Checkout our [starter-kit:e2e devicefarm config](https://github.com/telus/telus-isomorphic-starter-kit/blob/master/e2e/nightwatch.devicefarm.conf.js#L42)!
 
 </p></details>
 
@@ -106,7 +106,7 @@ FYI [Perfecto][perfecto] (who specializes in physical device testing) recommends
 
 <details><summary>Q: How are the devices managed?</summary><p> 
 
-- Software layer: For a short-term strategy, we currently just use selenium grid's console, as well as some shell scripts to manage the devices.  For a long term strategy, a proper MDM (mobile device management) system [needs to be established](https://github.com/telusdigital/farmville/issues/18).
+- Software layer: For a short-term strategy, we currently just use selenium grid's console, as well as some shell scripts to manage the devices.  For a long term strategy, a proper MDM (mobile device management) system [needs to be established](https://github.com/telus/farmville/issues/18).
 
 - Hardware / infrastructure: Currently manually managed
 
@@ -153,7 +153,7 @@ The rationale is that a farm can be "grown" or scaled up, whereas a lab is perce
 
 - Ask in #devicefarm on Slack
 - Contact @Nintendot / Slack: @benexpress / Email: ben.chen@telus.com
-- Contact @telusdigital/digital-farmers 
+- Contact @@telus/digital-farmers 
 
 </p></details>
 

--- a/testing/tools_platforms/devicefarming.md
+++ b/testing/tools_platforms/devicefarming.md
@@ -88,15 +88,15 @@ e.g:
 
 ## Who
 
-@telusdigital/digital-farmers @qa @peopleops
+@telus/digital-farmers @qa @peopleops
 
 ## References
 
-[sk]: https://github.com/telusdigital/telus-isomorphic-starter-kit/tree/master/e2e
+[sk]: https://github.com/telus/telus-isomorphic-starter-kit/tree/master/e2e
 
-[sk-dfconfig]: https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/e2e/nightwatch.devicefarm.conf.js
+[sk-dfconfig]: https://github.com/telus/telus-isomorphic-starter-kit/blob/master/e2e/nightwatch.devicefarm.conf.js
 
-[sk-dfconfig_selenium]: https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/e2e/nightwatch.devicefarm.conf.js#L41_L42
+[sk-dfconfig_selenium]: https://github.com/telus/telus-isomorphic-starter-kit/blob/master/e2e/nightwatch.devicefarm.conf.js#L41_L42
 
 [nw]: http://nightwatchjs.org/
 


### PR DESCRIPTION
## Overview

- Update all links & references to other repositories to use `telus` as the organization name (instead of `telusdigital`).
- Update all links & references to npm packages to use `telus` as the scope/org name (instead of `telusdigital`).

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-forks]: https://help.github.com/articles/syncing-a-fork/
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
