### PR TITLE
build(release): trying to make sem release work without npm publish

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,33 @@
+module.exports = {
+  verifyConditions: [
+    '@semantic-release/github',
+    '@semantic-release/changelog'
+  ],
+
+  analyzeCommits: [
+    '@semantic-release/commit-analyzer'
+  ],
+
+  generateNotes: [
+    '@semantic-release/release-notes-generator'
+  ],
+
+  prepare: [
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md",
+      "changelogTitle": "TELUS Reference Architecture Documentation Changelog"
+    }],
+  ],
+
+  publish: [
+    '@semantic-release/github'
+  ],
+
+  success: [
+    '@semantic-release/github'
+  ],
+
+  fail: [
+    '@semantic-release/github'
+  ]
+}

--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,13 @@ jobs:
       - attach
       - run: npm run lint
 
+  release:
+    executor: app
+    steps:
+      - attach
+      - ssh
+      - run: npx semantic-release
+
 workflows:
   version: 2
   run:
@@ -36,3 +43,10 @@ workflows:
       - build
       - lint:
           requires: [ build ]
+
+      - release:
+          context: npm-library
+          requires: [ build, lint ]
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
## Overview

Trying to add proper versioning and automated releases for this repo using `semantic-release`, but skipping the publishing to NPM part. Also trying to add changelog.

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-forks]: https://help.github.com/articles/syncing-a-fork/
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
