### PR TITLE
build(release): docs commits should trigger minor release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,7 +80,7 @@ You should usually open a pull request in the following situations:
 
 A pull request doesn't have to represent finished work. It's usually better to open a pull request early on, so others can watch or give feedback on your progress. Just mark it as a "WIP" (Work in Progress) in the subject line. You can always add more commits later.
 
-As your write commits, be sure to check the [pull request template](./PULL_REQUEST_TEMPLATE.md) for guidance.
+As your write commits, be sure to check the [pull request template](./PULL_REQUEST_TEMPLATE.md) for guidance. Your commits should follow the [karma format][karma-format]. 
 
 ## What happens after you submit a contribution
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,7 +80,7 @@ You should usually open a pull request in the following situations:
 
 A pull request doesn't have to represent finished work. It's usually better to open a pull request early on, so others can watch or give feedback on your progress. Just mark it as a "WIP" (Work in Progress) in the subject line. You can always add more commits later.
 
-As your write commits, be sure to check the [pull request template](./PULL_REQUEST_TEMPLATE.md) for guidance. Your commits should follow the [karma format][karma-format]. 
+As you write commits, be sure to check the [pull request template](./PULL_REQUEST_TEMPLATE.md) for guidance. Your commits should follow the [karma format][karma-format]. 
 
 ## What happens after you submit a contribution
 

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,6 @@
+{
+  "extends": "@telus/semantic-release-config/github",
+  "releaseRules": [
+    { "type": "docs", "release": "minor" }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -76,7 +76,15 @@ To ensure open collaboration and support for wiki contributions, a few avenues a
 
 - **Open Contribution**  
   Use GitHub to create pull-requests, start discussions, and contribute to active issues.
-  Your contributions should also be addressed in _The Technology Forum_ in order to be considered for adoption.
+  Your contributions should also be addressed in _The Technology Forum_ in order to be considered for adoption. 
+
+  If you are ready to start contributing, here are some things to keep in mind:
+  - This a versioned documentation repository, and commit messages follow the [karma format][karma-format].
+  - If you are adding new documentation or updating existing documentation, you should format your commits following this model: `docs(<scope>): added/updated standards about <scope>`. 
+  - If you are adding major sections or introducing major changes, then consider marking your commit as a breaking change.
+  - If you are only making corrections or fixing style/layout/punctuation/grammar, etc., then follow this model: `style(<scope>): fix grammar issues in <scope> docs`.
+  - For all other commits, follow the above mentioned Karma conventions.
+  - Feel free to consult our [CONTRIBUTING](./.github/CONTRIBUTING.md) guide for more guidance on how to contribute.
 
 #### Local development setup
 
@@ -113,3 +121,4 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 [bcp14]: https://tools.ietf.org/html/bcp14
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc8174]: https://tools.ietf.org/html/rfc8174
+[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html

--- a/package.json
+++ b/package.json
@@ -24,11 +24,5 @@
     "lint:md": "npx remark --quiet --frail .",
     "lint": "npx npm-run-all -p lint:*",
     "setup-local": "npx install-group peer --package @telus/build-essential --no-save"
-  },
-  "release": {
-    "extends": "@telus/semantic-release-config/github",
-    "releaseRules": [
-      { "type": "docs", "release": "minor" }
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "setup-local": "npx install-group peer --package @telus/build-essential --no-save"
   },
   "release": {
-    "extends" : "@telus/semantic-release-config/github"
+    "extends": "@telus/semantic-release-config/github",
+    "releaseRules": [
+      { "type": "docs", "release": "minor" }
+    ]
   }
 }


### PR DESCRIPTION
## Overview

Confirmed that this works (still extending centralized config, but adding a custom rule so that `docs` commits trigger minor releases. The default settings are for `docs` commits to not trigger a release, but it doesn't make sense for documentation repos such as this.

I also added more details in the README and in the CONTRIBUTING guide re. commit message conventions to follow.

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] fork is up to date _(Hint: ["Syncing a Fork"][guide-forks])_
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-forks]: https://help.github.com/articles/syncing-a-fork/
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
