### PR TITLE
docs(hardware): update XPS url to correct configuration page

### DIFF
--- a/equipment/README.md
+++ b/equipment/README.md
@@ -27,9 +27,9 @@ The hardware and tooling requirements below reflect an evolving standard. At TEL
 
 > 2.5GHz dual-core 7th generation Intel Core i7 processor, Turbo Boost up to 4.0GHz, RAM 16GB or more, 256/512GB SSD storage
 
-**[ThinkPad X1 Carbon (5th Gen)](https://www.lenovo.com/ca/en/laptops/thinkpad/thinkpad-x/ThinkPad-X1-Carbon-5th-Gen/p/22TP2TXX15G)**
+**[ThinkPad X1 Carbon (6th Gen)](https://www.lenovo.com/ca/en/laptops/thinkpad/thinkpad-x/ThinkPad-X1-Carbon-6th-Gen/p/22TP2TXX16G)**
 
-> Linux, 7th Generation Intel® Core™ i7-7500U Processor (2.70GHz, up to 3.50GHz, 4MB Cache), RAM 16 GB or more, 256/512GB SSD storage
+> Linux, 8th Generation Intel® Core™ i7-8550U (1.80GHz, up to 4.0GHz with Turbo Boost, 8MB Cache), RAM 16 GB or more, 256/512GB SSD storage
 
 **[Dell XPS 13 _(new model)_](https://www.dell.com/en-ca/shop/dell-laptops-netbooks-and-tablets/new-xps-13-laptop/spd/xps-13-9370-laptop?view=configurations&appliedRefinements=103)**
 

--- a/equipment/README.md
+++ b/equipment/README.md
@@ -31,7 +31,7 @@ The hardware and tooling requirements below reflect an evolving standard. At TEL
 
 > Linux, 8th Generation Intel® Core™ i7-8550U (1.80GHz, up to 4.0GHz with Turbo Boost, 8MB Cache), RAM 16 GB or more, 256/512GB SSD storage
 
-**[Dell XPS 13 _(new model)_](https://www.dell.com/en-ca/shop/dell-laptops-netbooks-and-tablets/new-xps-13-laptop/spd/xps-13-9370-laptop?view=configurations&appliedRefinements=103)**
+**[Dell XPS 13 _(new model)_](https://www.dell.com/en-ca/work/shop/laptops-ultrabooks/xps-13-developer-edition/spd/xps-13-9370-laptop/cax13w10p2c606ubuntuca)**
 
 > Linux, 8th Generation Intel® Core™ i7-8550U Processor (8M Cache, up to 4.0 GHz, 4 cores), RAM 16GB LPDDR3 2133MHz, 256/512GB PCIe SSD
 


### PR DESCRIPTION
## Overview

Dell upgraded their XPS laptops to the newer models. The URL for the Dell XPS no longer referred to a page with the proper configuration.

### Details

Updated the URL for the Dell XPS to a specific configuration for the XPS 13 2018 model closest to the previous suggested technical specifications as discussed with @ruxandrafed 

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [ ] documentation format follows the [topic template][template]
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [ ] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials
