### PR TITLE
docs(equipment): update link to correct latest Dell model

### DIFF
--- a/equipment/README.md
+++ b/equipment/README.md
@@ -31,9 +31,9 @@ The hardware and tooling requirements below reflect an evolving standard. At TEL
 
 > Linux, 8th Generation Intel® Core™ i7-8550U (1.80GHz, up to 4.0GHz with Turbo Boost, 8MB Cache), RAM 16 GB or more, 256/512GB SSD storage
 
-**[Dell XPS 13 _(new model)_](https://www.dell.com/en-ca/work/shop/laptops-ultrabooks/xps-13-developer-edition/spd/xps-13-9370-laptop/cax13w10p2c606ubuntuca)**
+**[Dell XPS 13 _(new model)_](https://www.dell.com/en-ca/work/shop/laptops-ultrabooks/xps-13-developer-edition/spd/xps-13-9380-laptop/cax13w10p1c707subuntuca)**
 
-> Linux, 8th Generation Intel® Core™ i7-8550U Processor (8M Cache, up to 4.0 GHz, 4 cores), RAM 16GB LPDDR3 2133MHz, 256/512GB PCIe SSD
+> 8th Generation Intel® Core™ i7-8565U Processor (8MB Cache, up to 4.6 GHz, 4 cores), RAM 16GB LPDDR3 2133MHz, 256/512GB PCIe SSD
 
 ### Software
 

--- a/equipment/README.md
+++ b/equipment/README.md
@@ -33,7 +33,7 @@ The hardware and tooling requirements below reflect an evolving standard. At TEL
 
 **[Dell XPS 13 _(new model)_](https://www.dell.com/en-ca/work/shop/laptops-ultrabooks/xps-13-developer-edition/spd/xps-13-9380-laptop/cax13w10p1c707subuntuca)**
 
-> 8th Generation Intel® Core™ i7-8565U Processor (8MB Cache, up to 4.6 GHz, 4 cores), RAM 16GB LPDDR3 2133MHz, 256/512GB PCIe SSD
+> Linux, 8th Generation Intel® Core™ i7-8565U Processor (8MB Cache, up to 4.6 GHz, 4 cores), RAM 16GB LPDDR3 2133MHz, 256/512GB PCIe SSD
 
 ### Software
 


### PR DESCRIPTION
The suggested Dell laptop we had in the docs isn't available anymore, as @icedfox has noticed a while back. The new developer edition is finally available for order on the Canadian website, so this PR updates the details and the link.

Thanks @icedfox for patiently waiting for this new model to be released in Canada and letting us know! 😄