### PR TITLE
fix(jira): adding a doc for developers for jira + github integration

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -28,6 +28,7 @@
 - [Caching](caching.md)
 - [Databases](databases.md)
 - [Git & GitHub](git.md)
+- [GitHub & Jira Integration](jira.md)
 - [Jest](jest.md)
 - [Logging](logging.md)
 - [NewRelic](newrelic.md)

--- a/development/jira.md
+++ b/development/jira.md
@@ -1,0 +1,51 @@
+# Jira + Github Integration
+
+## What
+
+Ever wonder how nice would it be if Jira already knew about this PR you're creating?
+
+Well, we're in luck because Jira has already been supporting GitHub integration. As of 2020, this is the official Jira app available for free on GitHub marketplace:
+https://marketplace.atlassian.com/apps/1219592/github-for-jira?hosting=cloud&tab=installation
+
+This app helps teams to automatically connect a PR in their repo to the appropriate Jira story. And below is a few tips on how to make the best use out of it.
+
+## How
+
+### Tagging a Jira Issue with Git or GitHub
+
+To tag a Jira story, you may add the Jira story number to one or more of the following in Git/GitHub:
+
+* branch name
+* pull request title
+* pull request descriptions
+* pull request comments
+
+The format varies depending on which method you choose to tag the story, as from the matrix below:
+
+| Format  | Branch Name | Git Commits | PR Title  | PR Comments  | Notes |
+|---|---|---|---|---|---|
+| `STORY-123`  | ✔ | ❌ | ❌ | ❌  | No need to put `[]` around  |
+| `STORY-123-hotfix`  | ✔  | ❌ |❌ | ❌  | Can append other strings  |
+| `feat/STORY-123-new-button` | ✔ | ❌ | ❌ | ❌  | Also allows prefixes |
+| `[STORY-123]`  | ❌ | ✔ | ✔ |✔ | `[]` should be used everywhere except in branch name  |
+
+Notes
+* Regardless of where you are inserting the story number, it **MUST BE ALL CAPS**.
+
+* Jira also syncs any future update of the tagged commits and PRs to its Jira story, so you will only ever need to tag the PR using one of the methods above. For instance, you may choose to create your branches by following the format `STORY-123` and don't have to worry about having to repeat it many times through your commits or PR.
+
+### Viewing related GitHub updates on a Jira Story
+
+![Jira Development Panel][panel]
+
+[panel]: https://confluence.atlassian.com/jirasoftwarecloud/files/777002795/947850193/1/1522126382029/Issue+with+dev+panel.png
+
+
+## Who
+
+Developers.
+
+## References
+
+Check the "How it works" section on this guide to learn more about Jira + Github:
+https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html

--- a/development/jira.md
+++ b/development/jira.md
@@ -36,6 +36,9 @@ Notes
 
 ### Viewing related GitHub updates on a Jira Story
 
+
+Example as shown per Jira documentation:
+
 ![Jira Development Panel][panel]
 
 [panel]: https://confluence.atlassian.com/jirasoftwarecloud/files/777002795/947850193/1/1522126382029/Issue+with+dev+panel.png


### PR DESCRIPTION
## Overview

Updates a simple documentation explaining how to automate GitHub updates to Jira.

**Forum Issue #** telus/technology-forum#374

### Details

- a new jira.md file
- a new link to the jira.md from the Development section

---

#### Meta

> Please read and confirm each of the following:

- [x] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] branch is up to date with master
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
