### PR TITLE
docs: correct where to get openshift CLI

### DIFF
--- a/delivery/openshift.md
+++ b/delivery/openshift.md
@@ -10,17 +10,12 @@ RedHat's OpenShift platform is (as of v3.0) an extension of Google's [Kubernetes
 
 ## How
 
-### Video Tutorials
-
-Use your Telus google account to view [YouTube Delivery Playlist](https://www.youtube.com/playlist?list=PLJgHilVD2rhL8Xne1UwpCwiVIB9F1JDL6)
-
 ### Clusters
 
 We currently have two deployed clusters, [main](https://console.telusdigital.openshift.com/) and [sandbox](https://console.telusdigitalsandbox.openshift.com/). The main cluster is intended for our official delivery pipelines, for any application that is intended to go live to customers. The sandbox is designed for short-lived testing: feature branches, test apps, etc. Don't expect projects on the sandbox environment to stick around too long... we purge it occasionally `:)`
 
 ### CLI
-
-Install the [OpenShift CLI](https://docs.openshift.org/latest/cli_reference/get_started_cli.html), to be able to access the cluster from your development workspace.
+Install the [OpenShift CLI](https://console.telusdigital.openshift.com/console/command-line), to be able to access the cluster from your development workspace.
 
 #### Login
 


### PR DESCRIPTION
remove youtube channel reference as it's been deleted

## Overview

Correcting some docs to the openshift CLI, and removing the youtube channel reference.


#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] branch is up to date with master
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
