### PR TITLE
docs: fix broken hyperlink

### DIFF
--- a/security/domain-management.md
+++ b/security/domain-management.md
@@ -38,7 +38,6 @@ When requesting a TELUS subdomain, keep in mind the following:
 
 ### 2) Requesting Digital Certificates
 
-
 To request a TLS certificate, the TELUS prime should refer to go/clm Certificate Lifecycle Management.
 
 Exceptions: if the application is behind WAF, IBP or is a (dot)digital app please email <mailto:dldigitalsecurity@telus.com> who will help you through the process.

--- a/security/privacy-policy.md
+++ b/security/privacy-policy.md
@@ -16,8 +16,8 @@ The user must be able to access the TELUS privacy policy at any stage when using
 
 Information on the privacy policy can be found here:
 
-- [Support - Privacy policy](https://www.telus.com/en/bc/support/privacy-policy)
-- [Privacy FAQ](https://www.telus.com/support/privacy-policy/assets/TELUS_Privacy_FAQ_EN.pdf?1517846227154)
+- [Telus - Privacy center](https://www.telus.com/en/about/privacy)
+- [Privacy FAQ](https://www.telus.com/en/about/privacy/faqs)
 
 ## Who
 


### PR DESCRIPTION
Updated the hyperlink to correct Telus Privacy resource destinations.