### PR TITLE
chore: transition master branch to main to opt for inclusive language

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@
 - [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
 - [ ] provided a descriptive topic and overview of contribution
 - [ ] documentation format follows the [topic template][template]
-- [ ] branch is up to date with master
+- [ ] branch is up to date with the `main` branch
 - [ ] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
 - [ ] commits follow the [Conventional ChangeLog][conventional-changelog] format
 - [ ] no sensitive content included, such as:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -60,8 +60,7 @@ branches:
       required_status_checks:
         strict: true
         contexts:
-          - 'ci/circleci: build'
-          - 'ci/circleci: lint'
+          - 'Validate'
 
       restrictions:
         teams:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -50,7 +50,7 @@ labels:
     color: D2DAE1
 
 branches:
-  - name: master
+  - name: main
     protection:
       required_pull_request_reviews:
         dismissal_restrictions:


### PR DESCRIPTION
## Overview

> Describe your change in detail
Altering the default Github branch from master to main to leverage inclusive language.

### Details

> e.g.
> - add something to existing topic
> - create new topic
> - adjust grammar & typos

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] branch is up to date with main
- [ ] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [ ] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
