### PR TITLE
chore: remove circle ci job reference

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -56,12 +56,6 @@ branches:
         dismissal_restrictions:
           teams:
             - architecture-support
-
-      required_status_checks:
-        strict: true
-        contexts:
-          - 'Validate'
-
       restrictions:
         teams:
           - architecture-support


### PR DESCRIPTION
## Overview

> Describe your change in detail

Removing hard reference to a circle CI job in Github settings

### Details

> e.g.
> - add something to existing topic
> - create new topic
> - adjust grammar & typos

---

#### Meta

> Please read and confirm each of the following:

- [ ] this topic was discussed in the [Technology Forum][technology-forum] _(ignore if the pull request represents small changes)_
- [x] provided a descriptive topic and overview of contribution
- [x] documentation format follows the [topic template][template]
- [x] branch is up to date with the `main` branch
- [x] "work in progress" commits are squashed _(Hint: ["Squashing Commits"][guide-squash])_
- [x] commits follow the [Conventional ChangeLog][conventional-changelog] format
- [x] no sensitive content included, such as:
  - content considered competitive intelligence
  - security & privacy policy violating content
  - keys, tokens or credentials

[template]: https://github.com/telus/reference-architecture/blob/master/.template.md
[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
[guide-squash]: https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History
[technology-forum]: https://github.com/telus/technology-forum]
